### PR TITLE
Filter BIOM table to sub-set

### DIFF
--- a/ipynb/filterEMP.ipynb
+++ b/ipynb/filterEMP.ipynb
@@ -1,0 +1,171 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Author**: stefan.m.janssen@gmail.com<br>\n",
+    "**Date**: 08 Aug 2016<br>\n",
+    "**language**: Python 3.5.2 :: Continuum Analytics, Inc.<br>\n",
+    "**conda enviroment**: micronota<br>\n",
+    "**license**: unlicensed<br>\n",
+    "\n",
+    "# Filter EMP\n",
+    "Currently the EMP comprises ~34k samples. Sometimes we need to operate on smaller sample numbers. Thus, the merged mapping file contains 'subset_xxx' columns, where xxx indicates the number of samples in the subset. These columns are np.boolean and flags if a sample of the whole EMP is part of subset xxx.\n",
+    "\n",
+    "There are several point where we need to filter full data-sets to those smaller subsets, e.g. BIOM tables. This notebook is an example of how to acomplish that. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# a trick to make it transparent if executed on a barnacle node or on my machine with barnacles file system mounted to /media/barnacle\n",
+    "import socket\n",
+    "ROOT = \"/media/barnacle/\" if socket.gethostname() == 't440s' else \"/\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "\n",
+    "# make all necessary imports\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import sys\n",
+    "import seaborn as sn\n",
+    "import matplotlib.pyplot as plt\n",
+    "import os\n",
+    "import biom\n",
+    "from biom.util import biom_open"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "the next cell contains all parameters that might need to be changed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# file_mapping points to the merged EMP mapping file, which contains columns like 'subset_2000'.\n",
+    "file_mapping = ROOT + '/projects/emp/00-qiime-maps/merged/emp_qiime_mapping_latest.tsv'\n",
+    "\n",
+    "# file_biom points to the full BIOM table\n",
+    "file_biom = ROOT + '/projects/emp/03-otus/01-closed-ref-greengenes/emp_cr_gg_13_8.biom'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "#we load the mapping file into a Pandas dataframe\n",
+    "metadata = pd.read_csv(file_mapping, sep=\"\\t\", index_col=0, low_memory=False)\n",
+    "\n",
+    "#we chose a (sub-)set of sample IDs which we want to have in our output set. E.g. all sampleIDs that have a np.True_ in the 'subset_2000' column, i.e. those 2000 samples that form the EMP 2000 sub-set \n",
+    "idx = metadata[metadata.empo_3 == 'Animal distal gut'].index"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loading source biom table ... which holds 27398 samples.\n",
+      "Sub-sampling down to 4508 of which 894 are not in the input BIOM table.\n",
+      "Writing resulting biom table to './filtered.biom'\n",
+      "Generating summary.\n"
+     ]
+    }
+   ],
+   "source": [
+    "filterBiomTable(idx, file_biom, \"./filtered.biom\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Reads a biom table from 'sourceBiomFile' and remains only those samples whose IDs are in the list 'sampleIDsToKeep'. Result will be written to the file 'targetBiomFile'\n",
+    "\n",
+    "def filterBiomTable(sampleIDsToKeep, sourceBiomFile, targetBiomFile):\n",
+    "    print(\"Loading source biom table ...\", end=\"\")\n",
+    "    counts = biom.load_table(sourceBiomFile)\n",
+    "    \n",
+    "    #collect available sample IDs from input biom table (some IDs of the list 'sampleIDsToKeep' might not be in the input biom file, e.g. if we don't have sequence reads)\n",
+    "    counts_idx = counts.ids('sample')\n",
+    "    print(\" which holds \" + str(len(counts_idx)) + \" samples.\")\n",
+    "\n",
+    "    toBeFiltered_idx = list(set(counts_idx) & set(sampleIDsToKeep))\n",
+    "    notFound = list(set(sampleIDsToKeep) - set(counts_idx))\n",
+    "    print(\"Sub-sampling down to \" + str(len(toBeFiltered_idx)) + \" of which \" + str(len(notFound)) + \" are not in the input BIOM table.\")\n",
+    "    \n",
+    "    #actual filtering\n",
+    "    counts_subset = counts.filter(toBeFiltered_idx, axis='sample', inplace=False)\n",
+    "    \n",
+    "    #create the new filename\n",
+    "    print(\"Writing resulting biom table to '\"+ targetBiomFile +\"'\")\n",
+    "    with biom_open(targetBiomFile, 'w') as f:\n",
+    "        counts_subset.to_hdf5(f, \"EMP sub-set generation notebook\")\n",
+    "        \n",
+    "    print(\"Generating summary.\")\n",
+    "    inp = targetBiomFile\n",
+    "    out = targetBiomFile + \".summary.txt\"\n",
+    "    !biom summarize-table -i \"$inp\" > \"$out\""
+   ]
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Raw Cell Format",
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
An examplary notebook to filter the full EMP BIOM tables down to those sampleIDs that are containted in EMP sub-sets.
